### PR TITLE
Increase the max solver iterations

### DIFF
--- a/PigInversion.py
+++ b/PigInversion.py
@@ -670,7 +670,11 @@ def main():
     if inversionParams['initWithDeg1']:
         Q1 = firedrake.FunctionSpace(mesh, family='CG', degree=1)
     area = firedrake.assemble(firedrake.Constant(1) * firedrake.dx(mesh))
-    opts = {'dirichlet_ids': meshOpts['dirichlet_ids']}  # Opts from mesh
+    opts = {
+        'dirichlet_ids': meshOpts['dirichlet_ids'],  ## Opts from mesh
+        'diagnostic_solver_parameters': {'max_iterations': 100}
+    }
+
     #
     # Input model geometry and velocity
     zb, s, h, floating, grounded = \


### PR DESCRIPTION
This change increases the max number of iterations for the diagnostic solver. I added regularization to Glen's flow law around zero strain rate to icepack, but with the default of 50 max iterations this makes the inverse solver fail. Increasing to 100 max iterations seems to make the code work again. On the first call to diagnostic solve, the initial guess is quite far from the final result, so the need to increase the number of iterations shouldn't be too concerning.